### PR TITLE
[proposal] Support multiple account usernames

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,10 @@ author:
   bio: >- # tell to the world
     The minimalist Jekyll theme, light and dark mode support, for running a personal site and blog, 
     meet Klisé theme at <a href="https://github.com/piharpi/jekyll-klise" target="_blank" rel="noopener">@github</a>.
-  username: username # social media username eg. github, twitter 
+  username: username # author username
+  github: github_username
+  twitter: twitter_username
+  facebook: facebook_username
   email: your-email@email.com # your contact adress
   avatar: /assets/img/avatar.jpg # change with your own avatar
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -59,20 +59,20 @@
   <meta
     property="og:site_name"
     content="{% if page.title %}{{ page.title | escape }} | {{
-      site.author.username
+      site.author.facebook
     }}{% else %}{{ site.title | escape }}{% endif %}"
   />
   <meta
     property="og:title"
     content="{% if page.title %}{{ page.title | escape }} | {{
-      site.author.username
+      site.author.facebook
     }}{% else %}{{ site.title | escape }}{% endif %}"
   />
   {% if page.location %}
   <meta property="og:type" content="article" />
   <meta
     property="article:publisher"
-    content="https://web.facebook.com/{{ site.author.username }}"
+    content="https://web.facebook.com/{{ site.author.facebook }}"
   />
   {% else %}
   <meta property="og:type" content="website" />
@@ -105,7 +105,7 @@
   <meta
     name="twitter:title"
     content="{% if page.title %}{{ page.title | escape }} | {{
-      site.author.username
+      site.author.twitter
     }}{% else %}{{ site.title | escape }}{% endif %}"
   />
   <meta
@@ -114,8 +114,8 @@
       page.url  | remove: 'index.html' | remove: '.html' | absolute_url
     }}"
   />
-  <meta name="twitter:site" content="@{{ site.author.username }}" />
-  <meta name="twitter:creator" content="@{{ site.author.username }}" />
+  <meta name="twitter:site" content="@{{ site.author.twitter }}" />
+  <meta name="twitter:creator" content="@{{ site.author.twitter }}" />
   <meta
     name="twitter:description"
     content="{{

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,7 +48,7 @@ layout: compress
           {% include anchor_headings.html html=content anchorClass="anchor-head" beforeHeading=true h_min=1 h_max=4 %}
           {% if page.tweet %}
           <p>Comments this article on 
-            <a href="https://twitter.com/{{site.username}}/status/{{page.tweet}}">Twitter</a>.
+            <a href="https://twitter.com/{{site.twitter}}/status/{{page.tweet}}">Twitter</a>.
           </p>
           {% endif %}
         </div>

--- a/about.md
+++ b/about.md
@@ -15,4 +15,4 @@ You can [report](http://github.com/piharpi/jekyll-klise/issues/new) if there is 
 ##### may u needs ✨
 
 - {{ site.author.email }}
-- github.com/{{ site.author.username }}
+- github.com/{{ site.author.github }}


### PR DESCRIPTION
Hey, first of all, thanks for the awesome template!

I'd like to propose that we separate the username handles for the different social media accounts a user of this template may have

Although they can do it themselves (if they're not on rush), I guess it's best if we implement this upfront to help them minimize the errors, eg. invalid meta tags for facebook and twitter.

Thank you!