### PR TITLE
Fix misaligned "no results found" text

### DIFF
--- a/_sass/klise/_base.scss
+++ b/_sass/klise/_base.scss
@@ -175,12 +175,12 @@ ol {
 ul,
 ol {
   margin-top: 0;
-  margin-left: $spacing-full;
 }
 
 li {
   padding-bottom: 1px;
   padding-top: 1px;
+  margin-left: $spacing-full;
 
   &:before {
     color: $black;


### PR DESCRIPTION
## Description
The "No results found" text is misaligned due to the left margin for lists being shifted by 30px. I've updated this so that instead of shifting the list itself, only the list items are shifted.

### Before
![before](https://user-images.githubusercontent.com/48141481/133432780-31c38133-d977-4201-a5c6-432a0141f570.png)

### After
![after](https://user-images.githubusercontent.com/48141481/133432778-888e7a97-708d-4472-b946-a60fb6fe51af.png)

