### PR TITLE
chore: Update _syntax.scss to center code block and set maximum width

### DIFF
--- a/_sass/klise/_syntax.scss
+++ b/_sass/klise/_syntax.scss
@@ -22,9 +22,10 @@ code {
 
 // Codeblock Theme
 pre.highlight, pre {
-  margin: 0 -27px;
+  margin: 0 auto; // Center the code block
+  max-width: 100%; // Set the maximum width of the code block to 100% of the parent container
   @include media-query($on-mobile) {
-    margin: 0 calc(51% - 51vw);
+    margin: 0 auto; // Center on mobile devices as well
     padding-left: 20px;
   }
   border: 1px solid rgba(128,128,128,0.1);
@@ -36,7 +37,7 @@ pre.highlight, pre {
 
   > code {
     width: 100%;
-    max-width: 50rem;
+    max-width: 100%; // Ensure the width of the code element does not exceed the pre element
     margin-left: auto;
     margin-right: auto;
     line-height: 1.5;


### PR DESCRIPTION
In the original style, the code blocks would exceed the maximum text width limits on both sides, which didn't look good. The new code corrects this issue, making the width of the code blocks consistent with the text width.

Old style:  
![iShot_2024-11-24_14 55 26](https://github.com/user-attachments/assets/a0812143-2625-480b-8562-35c6a25e8299)

New style: 
![iShot_2024-11-24_14 57 26](https://github.com/user-attachments/assets/9af13fce-1d69-4e7c-866e-2f69d00d3fd1)
